### PR TITLE
Make persistent disk writable by default user

### DIFF
--- a/mcs-deployment.yaml
+++ b/mcs-deployment.yaml
@@ -37,6 +37,8 @@ spec:
       labels:
         app: mc-server
     spec:
+      securityContext:
+        fsGroup: 1000
       containers:
       - image: ${IMAGE}
         name: mc-server


### PR DESCRIPTION
The itzg/minecraft image runs under the context of a custom user with uid=1000.
The persistent volume, by default, is only writable by root.
As a result, trying to bring this up fails because the EULA cannot be written to /data.
This setting fixes it.
See https://stackoverflow.com/a/46769504/197860